### PR TITLE
replace deprecated sudo with become

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ None.
 ## Example Playbook
 
     - hosts: servers
-      sudo: yes
+      become: true
       roles:
         - geerlingguy.clamav
 


### PR DESCRIPTION
I copied the example into a playbook and `ansible-lint` suggested I use become instead of sudo. Seems worth updating the example.

Thanks!