### PR TITLE
Allow creating new lines in clamav_daemon_config_path

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
 - name: Change configuration for the ClamAV daemon.
   lineinfile:
     path: "{{ clamav_daemon_config_path }}"
-    regexp: '{{ item.regexp }}'
+    regexp: '{{ item.regexp | default(omit) }}'
     line: "{{ item.line | default('') }}"
     state: "{{ item.state | default('present') }}"
   with_items: "{{ clamav_daemon_configuration_changes }}"


### PR DESCRIPTION
Hello @geerlingguy 
Firstly, I would like to thank you for your amazing work. I’m currently using several of your roles  on my instances.
I am currently configuring ClamAV via Ansible on several instances. This role performs all the changes I need except one. In addition to modifying  some parameters in _clamav_daemon_config_path_, I also need to add some lines.
It is possible to do it with the _lineinfile_ module, specifying the parameters _path_, _line_ and _state_. 
In the current code for the task _Change configuration for the ClamAV daemon_, the use of the parameter _regexp_ is compulsory. I just added the possibility to omit this parameter, allowing you to create new lines. You will still be able to modify existing ones.
Regards
