### PR TITLE
Added support for configuration changes to freshclam.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Available variables are listed below, along with default values (see `defaults/m
 
     clamav_daemon_localsocket: /var/run/clamav/clamd.ctl
     clamav_daemon_config_path: /etc/clamav/clamd.conf
+    clamav_freshclam_daemon_config_path: /etc/freshclam.conf
 
 Path configuration for ClamAV daemon. These are hardcoded specifically for each OS family (Debian and Red Hat) and cannot be overidden.
 
@@ -36,6 +37,14 @@ Changes to make to the configuration file that is read from when ClamAV starts. 
     clamav_daemon_enabled: true
 
 Control whether the `clamav-daemon` service is running and/or enabled on system boot.
+
+    clamav_freshclam_configuration_changes:
+      - regexp: '^.*HTTPProxyServer .*$'
+        line: 'HTTPProxyServer {{ clamav_freshclam_http_proxy_server }}'
+      - regexp: '^.*HTTPProxyPort .*$'
+        line: 'HTTPProxyPort {{ clamav_freshclam_http_proxy_port }}'
+
+Changes to make to the configuration file that is read from when freshclam starts. You will need to add your HTTP Proxy server configuration here, if you have one.
 
     clamav_freshclam_daemon_state: started
     clamav_freshclam_daemon_enabled: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 # See the defaults for OS-specific vars inside the vars/ directory.
 # clamav_packages: []
 # clamav_daemon_config_path: ''
+# clamav_freshclam_daemon_config_path: ''
 
 clamav_daemon_configuration_changes:
   - regexp: '^.*Example$'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,11 @@
   with_items: "{{ clamav_freshclam_configuration_changes }}"
   when: clamav_freshclam_configuration_changes is defined
 
+- name: Set permissions on /var/lib/clamav
+  file: /var/lib/clamav
+  owner: clamupdate
+  group: clamupdate
+
 - name: Ensure ClamAV daemon is running (if configured).
   service:
     name: "{{ clamav_daemon }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,9 +41,10 @@
   when: clamav_freshclam_configuration_changes is defined
 
 - name: Set permissions on /var/lib/clamav
-  file: /var/lib/clamav
-  owner: clamupdate
-  group: clamupdate
+  file:
+    path: /var/lib/clamav
+    owner: clamupdate
+    group: clamupdate
 
 - name: Ensure ClamAV daemon is running (if configured).
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,6 +31,15 @@
     state: "{{ item.state | default('present') }}"
   with_items: "{{ clamav_daemon_configuration_changes }}"
 
+- name: Change configuration for the freshclam daemon.
+  lineinfile:
+    path: "{{ clamav_freshclam_daemon_config_path }}"
+    regexp: '{{ item.regexp }}'
+    line: "{{ item.line | default('') }}"
+    state: "{{ item.state | default('present') }}"
+  with_items: "{{ clamav_freshclam_configuration_changes }}"
+  when: clamav_freshclam_configuration_changes is defined
+
 - name: Ensure ClamAV daemon is running (if configured).
   service:
     name: "{{ clamav_daemon }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,6 +1,7 @@
 ---
 clamav_daemon_localsocket: /var/run/clamav/clamd.ctl
 clamav_daemon_config_path: /etc/clamav/clamd.conf
+clamav_freshclam_daemon_config_path: /etc/freshclam.conf
 __clamav_daemon: 'clamav-daemon'
 __clamav_freshclam_daemon: 'clamav-freshclam'
 __clamav_packages:

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -8,3 +8,4 @@ __clamav_packages:
   - clamav
   - clamav-update
   - clamav-scanner-systemd
+  - clamav-data

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,6 +1,7 @@
 ---
 clamav_daemon_localsocket: /var/run/clamd.scan/clamd.sock
 clamav_daemon_config_path: /etc/clamd.d/scan.conf
+clamav_freshclam_daemon_config_path: /etc/freshclam.conf
 __clamav_daemon: 'clamd@scan'
 __clamav_freshclam_daemon: 'clamd-freshclam'
 __clamav_packages:


### PR DESCRIPTION
Some corporate networks require the use of proxy servers to connect to the internet.

These changes enable support for configuring an HTTP Proxy Server in /etc/freshclam.conf