### PR TITLE
Adding epel-release package for Redhat distros

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,6 +4,7 @@ clamav_daemon_config_path: /etc/clamd.d/scan.conf
 __clamav_daemon: 'clamd@scan'
 __clamav_freshclam_daemon: 'clamd-freshclam'
 __clamav_packages:
+  - epel-release
   - clamav
   - clamav-update
   - clamav-scanner-systemd


### PR DESCRIPTION
I had errors using the role on CentOS 8, etc:

```
TASK [ansible-role-clamav : Ensure ClamAV packages are installed.] **************************************************************************************************************************************************************************
Thursday 14 January 2021  12:44:42 -0500 (0:00:00.048)       0:00:02.104 ******
failed: [aws-centos8] (item=clamav) => {"ansible_loop_var": "item", "changed": false, "failures": ["No package clamav available."], "item": "clamav", "msg": "Failed to install some of the specified packages", "rc": 1, "results": []}
failed: [aws-centos8] (item=clamav-update) => {"ansible_loop_var": "item", "changed": false, "failures": ["No package clamav-update available."], "item": "clamav-update", "msg": "Failed to install some of the specified packages", "rc": 1, "results": []}
failed: [aws-centos8] (item=clamav-scanner-systemd) => {"ansible_loop_var": "item", "changed": false, "failures": ["No package clamav-scanner-systemd available."], "item": "clamav-scanner-systemd", "msg": "Failed to install some of the specified packages", "rc": 1, "results": []}
failed: [aws-centos7] (item=clamav) => {"ansible_loop_var": "item", "changed": false, "item": "clamav", "msg": "No package matching 'clamav' found available, installed or updated", "rc": 126, "results": ["No package matching 'clamav' found available, installed or updated"]}
failed: [aws-centos7] (item=clamav-update) => {"ansible_loop_var": "item", "changed": false, "item": "clamav-update", "msg": "No package matching 'clamav-update' found available, installed or updated", "rc": 126, "results": ["No package matching 'clamav-update' found available, installed or updated"]}
failed: [aws-centos7] (item=clamav-scanner-systemd) => {"ansible_loop_var": "item", "changed": false, "item": "clamav-scanner-systemd", "msg": "No package matching 'clamav-scanner-systemd' found available, installed or updated", "rc": 126, "results": ["No package matching 'clamav-scanner-systemd' found available, installed or updated"]}
```

The [installation instructions for RHEL and CentOS](https://www.clamav.net/documents/installing-clamav#rhel) say that the `epel-release` package is required.  I was able to install on CentOS 7 and 8 after adding that package to the list of packages for Redhat.