### PR TITLE
Overriding umask

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
   register: clamav_packages_install
 
 - name: Run freshclam after ClamAV packages change.
-  command: freshclam
+  shell: umask 022 && freshclam
   when: clamav_packages_install.changed
   register: freshclam_result
   notify: restart clamav daemon

--- a/templates/clamd-freshclam.service.j2
+++ b/templates/clamd-freshclam.service.j2
@@ -8,6 +8,7 @@ Type = forking
 ExecStart = /usr/bin/freshclam --daemon --checks 2
 Restart = on-failure
 PrivateTmp = true
+UMask = 022
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I observed that if you ran the role on a "hardened" system that specified umask 077 in /etc/profile, the clamd scanner service might fail.  `journalctl -xe` shows:

```
-- Unit clamd@scan.service has begun starting up.
Jan 21 13:02:04 ip-172-31-62-254.ec2.internal clamd[1763]: Received 0 file descriptor(s) from systemd.
Jan 21 13:02:04 ip-172-31-62-254.ec2.internal clamd[1762]: LibClamAV Error: cli_load(): Can't open file /var/lib/clamav/daily.cvd
Jan 21 13:02:04 ip-172-31-62-254.ec2.internal clamd[1762]: LibClamAV Error: cli_loaddbdir(): error loading database /var/lib/clamav/daily.cvd
Jan 21 13:02:04 ip-172-31-62-254.ec2.internal clamd[1762]: LibClamAV Error: cli_loaddbdir(): No supported database files found in /var/lib/clamav
Jan 21 13:02:04 ip-172-31-62-254.ec2.internal clamd[1762]: ERROR: Can't open file or directory
```

At the time of the error, the `/var/lib/clamav` files are:

```
-rw-------. 1 clamupdate clamupdate    296388 Jan 20 20:02 bytecode.cvd
-rw-------. 1 clamupdate clamupdate 110819851 Jan 20 20:01 daily.cvd
-rw-------. 1 clamupdate clamupdate 117859675 Jan 20 20:02 main.cvd
```

I made changes to the role to override the umask to make the files readable elsewhere and allow the service to start.
