### PR TITLE
Allow dependabot to check gha

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This change allows dependabot to check any GitHub action which this project uses and automatically submit pull requests with version bumps in order to keep dependencies up-to-date.