### PR TITLE
Fix linting workflow due to lack of ansibe package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install yamllint ansible-lint
+        run: pip3 install yamllint ansible ansible-lint
 
       - name: Lint code.
         run: |


### PR DESCRIPTION
It appears that the linting workflow is broken. `ansible-lint` is complaining that the `ansible` package is not installed. This change installs ansible apart of the install dependencies step in the workflow. Below shows that this error happening starting from Feb 13th.

https://github.com/geerlingguy/ansible-role-clamav/runs/1895795349?check_suite_focus=true#step:5:10