### PR TITLE
Restart clamav daemon after configuration change

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,6 +31,7 @@
     state: "{{ item.state | default('present') }}"
     mode: 0644
   with_items: "{{ clamav_daemon_configuration_changes }}"
+  notify: restart clamav daemon
 
 - name: Ensure ClamAV daemon is running (if configured).
   service:


### PR DESCRIPTION
Adding the notify to this task ensures the daemon is restarted after changes have been made.