### PR TITLE
Create socket directory for RedHat installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,4 @@ MIT / BSD
 ## Author Information
 
 This role was created in 2017 by [Jeff Geerling](https://www.jeffgeerling.com/), author of [Ansible for DevOps](https://www.ansiblefordevops.com/).
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,7 +36,7 @@
   file:
     dest: /var/run/clamd.scan/
     state: directory
-    user: clamscan
+    owner: clamscan
     group: virusgroup
     mode: 0722
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,7 @@
     state: directory
     owner: clamscan
     group: virusgroup
-    mode: 0722
+    mode: 0711
   when: ansible_os_family == 'RedHat'
 
 - name: Ensure ClamAV daemon is running (if configured).

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,6 +32,14 @@
     mode: 0644
   with_items: "{{ clamav_daemon_configuration_changes }}"
 
+- name: Create ClamAV socket directory in advance
+  file:
+    dest: /var/run/clamd.scan/
+    state: directory
+    user: clamscan
+    group: virusgroup
+    mode: 0722
+
 - name: Ensure ClamAV daemon is running (if configured).
   service:
     name: "{{ clamav_daemon }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,7 @@
     owner: clamscan
     group: virusgroup
     mode: 0722
+  when: ansible_os_family == 'RedHat'
 
 - name: Ensure ClamAV daemon is running (if configured).
   service:


### PR DESCRIPTION
Solves #22 

This is a "proposed" fix, seems to solve the issue

Could move the task to `setup-RedHat.yml` and/or add variables to user/group.

For now I leave it as is, since it solves my problem and may be useful for other people to know about.

Also added a pretask to my playbook to remove SELinux restrictions from ClamAV process
```
    - name: Unrestrict ClamAV from SELinux
      shell: semanage permissive -a antivirus_t
```

```
audit2allow -w -a
type=AVC msg=audit(1631814186.640:279): avc:  denied  { create } for  pid=8828 comm="clamd" name="clamd.sock" scontext=system_u:system_r:antivirus_t:s0 tcontext=system_u:object_r:var_run_t:s0 tclass=sock_file permissive=0
	Was caused by:
		Missing type enforcement (TE) allow rule.

		You can use audit2allow to generate a loadable module to allow this access.

```

```
audit2allow -a


#============= antivirus_t ==============

#!!!! WARNING 'antivirus_t' is not allowed to write or create to var_run_t.  Change the label to antivirus_var_run_t.
allow antivirus_t var_run_t:sock_file create;
```

  Not really sure what to do with this warning, someone with more experience feel free to chip in.