### PR TITLE
Fix check mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,9 +38,11 @@
     name: "{{ clamav_daemon }}"
     state: "{{ clamav_daemon_state }}"
     enabled: "{{ clamav_daemon_enabled }}"
+  when: not ansible_check_mode
 
 - name: Ensure ClamAV freshclam daemon is running (if configured).
   service:
     name: "{{ clamav_freshclam_daemon }}"
     state: "{{ clamav_freshclam_daemon_state }}"
     enabled: "{{ clamav_freshclam_daemon_enabled }}"
+  when: not ansible_check_mode

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
   failed_when:
     - freshclam_result is failed
     - freshclam_result.stderr.find('locked by another process') != -1
-  tags: ['skip_ansible_lint']
+  tags: ["skip_ansible_lint"]
 
 - include_tasks: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
@@ -26,10 +26,11 @@
 - name: Change configuration for the ClamAV daemon.
   lineinfile:
     path: "{{ clamav_daemon_config_path }}"
-    regexp: '{{ item.regexp }}'
+    regexp: "{{ item.regexp }}"
     line: "{{ item.line | default('') }}"
     state: "{{ item.state | default('present') }}"
     mode: 0644
+    create: yes
   with_items: "{{ clamav_daemon_configuration_changes }}"
 
 - name: Ensure ClamAV daemon is running (if configured).


### PR DESCRIPTION
Hello @geerlingguy, thank you for this module.
I'd like to add the check-mode compatibility with the two following changes:
- Avoid error `Destination /etc/clamav/clamd.conf does not exist !` by adding `create: yes` to `lineinfile`
- Avoid error `Could not find the requested service clamav-daemon: host` by skipping the tasks `service`