### PR TITLE
[Bugfix] Prevent clam-data to be download as dep

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,8 +5,7 @@
 - include_tasks: setup-vars.yml
 
 - name: Ensure ClamAV packages are installed.
-  package: name={{ item }} state=present
-  with_items: "{{ clamav_packages }}"
+  package: name={{ clamav_packages }} state=present
   register: clamav_packages_install
 
 - name: Run freshclam after ClamAV packages change.


### PR DESCRIPTION
clam-data is pulled as dependency of clamav because of the unnecessary package loop.
Without loop, it's alright !

fixing #26