### PR TITLE
Run tasks only if specific packages are installed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,6 +32,7 @@
     mode: 0644
     create: yes
   with_items: "{{ clamav_daemon_configuration_changes }}"
+  when: clamav_packages == "clamav-daemon"
 
 - name: Change configuration for the freshclam daemon.
   lineinfile:
@@ -47,7 +48,9 @@
     name: "{{ clamav_daemon }}"
     state: "{{ clamav_daemon_state }}"
     enabled: "{{ clamav_daemon_enabled }}"
-  when: not ansible_check_mode
+  when:
+    - not ansible_check_mode
+    - clamav_packages == "clamav-daemon"
 
 - name: Ensure ClamAV freshclam daemon is running (if configured).
   service:


### PR DESCRIPTION
The clamav daemon is missing on the system if not explicitly installed (via clamav_packages: clamav-daemon).

Therefore the service tasks fails without the condition.