### PR TITLE
Ensure restart of clamd after configuration changes

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,6 +31,7 @@
     state: "{{ item.state | default('present') }}"
     mode: 0644
     create: yes
+  notify: restart clamav daemon
   with_items: "{{ clamav_daemon_configuration_changes }}"
 
 - name: Change configuration for the freshclam daemon.


### PR DESCRIPTION
When changing config after first installation, clamd is not restarted.