### PR TITLE
Debian/Ubuntu: Fix location of freshclam.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Available variables are listed below, along with default values (see `defaults/m
 
     clamav_daemon_localsocket: /var/run/clamav/clamd.ctl
     clamav_daemon_config_path: /etc/clamav/clamd.conf
-    clamav_freshclam_daemon_config_path: /etc/freshclam.conf
+    clamav_freshclam_daemon_config_path: /etc/clamav/freshclam.conf
 
 Path configuration for ClamAV daemon. These are hardcoded specifically for each OS family (Debian and Red Hat) and cannot be overidden.
 

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,7 +1,7 @@
 ---
 clamav_daemon_localsocket: /var/run/clamav/clamd.ctl
 clamav_daemon_config_path: /etc/clamav/clamd.conf
-clamav_freshclam_daemon_config_path: /etc/freshclam.conf
+clamav_freshclam_daemon_config_path: /etc/clamav/freshclam.conf
 __clamav_daemon: 'clamav-daemon'
 __clamav_freshclam_daemon: 'clamav-freshclam'
 __clamav_packages:


### PR DESCRIPTION
On Ubuntu, when trying to apply any freshclam config updates via `clamav_freshclam_configuration_changes`, I'm seeing the following error:

> TASK [geerlingguy.clamav : Change configuration for the freshclam daemon.] *****
>
> Wednesday 31 July 2024  13:43:47 +1200 (0:00:01.291)       0:04:59.151 ********
>
> failed: [default] (item={'regexp': '^.*TestDatabases .*$', 'line': 'TestDatabases False'}) => {"ansible_loop_var": "item", "changed": false, "item": {"line": "TestDatabases False", "regexp": "^.*TestDatabases .*$"}, "msg": "Destination /etc/freshclam.conf does not exist !", "rc": 257}

After investigating the issue, I think the default freshclam config path set in this role is incorrect.

For Debian/Ubuntu, as far as I can tell, the freshclam config file was never located at `/etc/freshclam.conf`, but instead is at `/etc/clamav/freshclam.conf`.

Here is the relevant documentation for the oldest supported OS releases by this role, confirming the *correct* location to be `/etc/clamav/freshclam.conf`:
* jessie: https://manpages.debian.org/jessie/clamav-freshclam/freshclam.conf.5.en.html
* xenial: https://manpages.ubuntu.com/manpages/xenial/en/man5/freshclam.conf.5.html