### PR TITLE
Made changes to allow role to work with rpm-ostree systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ Changes to make to the configuration file that is read from when freshclam start
 
 Control whether the `clamav-freshclam` service is running and/or enabled on system boot.
 
+## libostree
+
+If you want the role to function with an immutable (ostree) file system, then you will
+need to define the following variable:
+```
+    ansible_package_use: community.general.rpm_ostree_package
+``` 
+Currently only Fedora and RHEL systems that support rpm_ostree are supported.
+
 ## Dependencies
 
 None.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
 - include_tasks: setup-vars.yml
 
 - name: Ensure ClamAV packages are installed.
-  package: "{{ clamav_packages | join(' ') }}"
+  package: "{{ clamav_packages }}"
   register: clamav_packages_install
 
 - name: Reboot if necessary (when rpm-ostree is package manager)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
   when:
     - ansible_package_use is defined
     - '"rpm_ostree_pkg" in ansible_package_use'
-    - clamav_packages_install.needs_reboot
+    - clamav_packages_install.results[0].needs_reboot is true | bool
 
 - name: Run freshclam after ClamAV packages change.
   command: freshclam

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
   when:
     - ansible_package_use is defined
     - '"rpm_ostree_pkg" in ansible_package_use'
-    - clamav_packages_install.reboot_required
+    - clamav_packages_install.needs_reboot
 
 - name: Run freshclam after ClamAV packages change.
   command: freshclam

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,8 +5,7 @@
 - include_tasks: setup-vars.yml
 
 - name: Ensure ClamAV packages are installed.
-  package: name={{ item }} state=present
-  with_items: "{{ clamav_packages | join(' ') }}"
+  package: "{{ clamav_packages | join(' ') }}"
   register: clamav_packages_install
 
 - name: Reboot if necessary (when rpm-ostree is package manager)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: Ensure ClamAV packages are installed.
   package: name={{ item }} state=present
-  with_items: "{{ clamav_packages }}"
+  with_items: "{{ clamav_packages | join(' ') }}"
   register: clamav_packages_install
 
 - name: Run freshclam after ClamAV packages change.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,11 @@
   with_items: "{{ clamav_packages | join(' ') }}"
   register: clamav_packages_install
 
+- name: Reboot if necessary (when rpm-ostree is package manager)
+  ansible.builtin.reboot:
+    msg: "Reboot initiated by Ansible"
+  when: 'ansible_package_use is defined and rpm_ostree_pkg in ansible_package_use'
+
 - name: Run freshclam after ClamAV packages change.
   command: freshclam
   when: clamav_packages_install.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,8 @@
 - include_tasks: setup-vars.yml
 
 - name: Ensure ClamAV packages are installed.
-  package: "{{ clamav_packages }}"
+  package: 
+    name: "{{ clamav_packages }}"
   register: clamav_packages_install
 
 - name: Reboot if necessary (when rpm-ostree is package manager)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
     msg: "Reboot initiated by Ansible"
   when:
     - ansible_package_use is defined
-    - '"{{ rpm_ostree_pkg }}" in ansible_package_use'
+    - '"rpm_ostree_pkg" in ansible_package_use'
     - clamav_packages_install.reboot_required
 
 - name: Run freshclam after ClamAV packages change.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,6 @@
 
 - name: Run freshclam after ClamAV packages change.
   command: freshclam
-  when: clamav_packages_install.changed
   register: freshclam_result
   notify: restart clamav daemon
   # On Debian, freshclam is automatically run post-install, so this may fail.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,10 @@
 - name: Reboot if necessary (when rpm-ostree is package manager)
   ansible.builtin.reboot:
     msg: "Reboot initiated by Ansible"
-  when: 'ansible_package_use is defined and rpm_ostree_pkg in ansible_package_use'
+  when:
+    - ansible_package_use is defined
+    - '"{{ rpm_ostree_pkg }}" in ansible_package_use'
+    - clamav_packages_install.reboot_required
 
 - name: Run freshclam after ClamAV packages change.
   command: freshclam

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -2,7 +2,7 @@
 - name: Ensure Freshclam service is available.
   template:
     src: clamd-freshclam.service.j2
-    dest: /lib/systemd/system/clamd-freshclam.service
+    dest: /etc/systemd/system/clamd-freshclam.service
     mode: 0644
   register: freshclam_service_template
 


### PR DESCRIPTION
Changed tasks/main.yml to make install task more efficient.  Instead of looping packages sequentially, all packages can be installed simultaneously by passing the list of packages to the name parameter.

Added a reboot check to reboot the remote system if it is an rpm-ostree system and packages have been installed.

Changed the path for the systemd service from /lib to /etc.  This allows the role to write its systemd service template as a dropin to the /etc/systemd/system folder, which is compatible with all rhel and fedora systems.  The existing path, /lib/systemd/system is unwritable on rpm-ostree systems.

Edited the readme to add the need for `ansible_package_use = rpm_ostree_package` to be defined for the role to work with systems with rpm-ostree based immutable filesystems.